### PR TITLE
fix: correct AI workflow doc file references to prevent read:file_not_found errors

### DIFF
--- a/.ai-workflows/bug-fixing.md
+++ b/.ai-workflows/bug-fixing.md
@@ -144,12 +144,12 @@ Apply the minimal fix necessary to address the critical issue.
 
 Increment the PATCH version and update all version numbers:
 
-- Main plugin file (fix-plugin-does-not-exist-notices.php)
+- Main plugin file (wp-fix-plugin-does-not-exist-notices.php)
 - FPDEN_VERSION constant
 - CHANGELOG.md
 - readme.txt
 - README.md
-- languages/fix-plugin-does-not-exist-notices.pot (Project-Id-Version)
+- languages/wp-fix-plugin-does-not-exist-notices.pot (Project-Id-Version)
 
 ### 4. Commit and Push
 

--- a/.ai-workflows/feature-development.md
+++ b/.ai-workflows/feature-development.md
@@ -27,7 +27,6 @@ When implementing a new feature:
 - Add appropriate comments
 - Consider performance implications
 - Maintain backward compatibility
-- Review reference plugins in the `reference-plugins/` directory for inspiration and best practices
 
 ### 3. Update Documentation
 

--- a/.ai-workflows/folder-structure.md
+++ b/.ai-workflows/folder-structure.md
@@ -28,9 +28,9 @@ This document outlines the folder structure of the plugin and explains the purpo
 
 The `includes/` directory contains the core plugin functionality:
 
-- **includes/core.php** - Core class for handling the main plugin functionality
-- **includes/plugin.php** - Main plugin class that initializes all components
-- **includes/updater.php** - Updater class for handling plugin updates
+- **includes/Core.php** - Core class for handling the main plugin functionality
+- **includes/Plugin.php** - Main plugin class that initializes all components
+- **includes/Updater.php** - Updater class for handling plugin updates
 
 ## File Naming Conventions
 
@@ -50,10 +50,10 @@ The `includes/` directory contains the core plugin functionality:
 
 When referring to files or directories in AI conversations, use the following format:
 
-- **@includes/plugin.php** - Main plugin class
-- **@includes/core.php** - Core functionality
+- **@includes/Plugin.php** - Main plugin class
+- **@includes/Core.php** - Core functionality
 - **@admin/lib/admin.php** - Admin functionality
 - **@admin/lib/modal.php** - Modal functionality
-- **@includes/updater.php** - Updater functionality
+- **@includes/Updater.php** - Updater functionality
 - **@admin/js/update-source-selector.js** - Update source selector JavaScript
 - **@admin/css/update-source-selector.css** - Update source selector CSS


### PR DESCRIPTION
## Summary

Fixes incorrect file path references in AI workflow documentation that were causing cascading tool errors in AI assistant sessions.

## Root Cause

Three documentation files contained wrong file paths that don't match actual files on disk:

1. **`.ai-workflows/folder-structure.md`** — referenced `includes/core.php`, `includes/plugin.php`, `includes/updater.php` (lowercase) but actual files use PascalCase: `includes/Core.php`, `includes/Plugin.php`, `includes/Updater.php`

2. **`.ai-workflows/bug-fixing.md`** — referenced `fix-plugin-does-not-exist-notices.php` and `languages/fix-plugin-does-not-exist-notices.pot` (missing `wp-` prefix) instead of the correct `wp-fix-plugin-does-not-exist-notices.php` and `languages/wp-fix-plugin-does-not-exist-notices.pot`

3. **`.ai-workflows/feature-development.md`** — referenced `reference-plugins/` directory that does not exist in the repository

## Error Cascade

Incorrect paths in documentation cause AI assistants to:
1. Try to read non-existent paths — `read:file_not_found` (23x observed)
2. Proceed to edit without successful read — `edit:not_read_first` (71x observed)
3. Read stale/wrong file then edit different target — `edit:edit_stale_read` (32x observed)
4. Execute commands with wrong filenames — `bash:other` (66x observed)

## Changes

- `.ai-workflows/folder-structure.md`: Fix 6 file references (3 in Includes Directory section, 3 in @mentions section) to use correct PascalCase
- `.ai-workflows/bug-fixing.md`: Fix 2 file references in Hotfix section to include `wp-` prefix
- `.ai-workflows/feature-development.md`: Remove reference to non-existent `reference-plugins/` directory

Resolves #16

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 4m and 13,517 tokens on this as a headless worker.
