### PR TITLE
fix: replace ambiguous X.Y.Z placeholder with actual version in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ CHANGELOG.md                                # Changelog (keep in sync with READM
 
 Version appears in **four places** — all must be updated together:
 
-1. `wp-fix-plugin-does-not-exist-notices.php` — `Version:` header and `new Plugin(__FILE__, 'X.Y.Z')`
+1. `wp-fix-plugin-does-not-exist-notices.php` — `Version:` header and `new Plugin(__FILE__, '2.4.0')` (replace `2.4.0` with the new version)
 2. `includes/Plugin.php` — no direct version constant; version passed via constructor
 3. `readme.txt` — `Stable tag:` and changelog section
 4. `CHANGELOG.md` — top entry


### PR DESCRIPTION
## Summary

Resolves #19

Addresses Gemini review feedback from PR #14: the `X.Y.Z` placeholder in the Version Management section of `AGENTS.md` is ambiguous for AI agents, who may interpret it literally or fail to match it during automated find-and-replace edits.

## Change

**File**: `AGENTS.md:56`

The current actual version `2.4.0` is used so agents can grep for the exact string and verify it matches. The parenthetical clarifies that this should be updated on version bumps.

## Verification

```bash
grep "new Plugin" AGENTS.md
# Expected: ...new Plugin(__FILE__, '2.4.0')...
```


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 8,711 tokens on this as a headless worker.
