### PR TITLE
fix: correct class name and version locations in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,12 @@ CHANGELOG.md                                # Changelog (keep in sync with READM
 
 Version appears in **four places** — all must be updated together:
 
-1. `wp-fix-plugin-does-not-exist-notices.php` — `Version:` header and `new Plugin(__FILE__, '2.4.0')` (replace `2.4.0` with the new version)
-2. `includes/Plugin.php` — no direct version constant; version passed via constructor
-3. `readme.txt` — `Stable tag:` and changelog section
-4. `CHANGELOG.md` — top entry
+1. `wp-fix-plugin-does-not-exist-notices.php` — `Version:` header and `new WPALLSTARS\FixPluginDoesNotExistNotices\Plugin(__FILE__, '2.4.0')` (replace `2.4.0` with the new version)
+2. `readme.txt` — `Stable tag:` and changelog section
+3. `CHANGELOG.md` — top entry
+4. `AGENTS.md` — this file, item 1 above (replace the hardcoded version string)
+
+Note: `includes/Plugin.php` has no direct version constant; the version is passed in via the constructor call in the entry point file.
 
 `README.md` changelog section must also stay in sync with `CHANGELOG.md`.
 
@@ -77,6 +79,7 @@ JS: `admin/js/admin-scripts.js` or `admin/js/update-source-selector.js`.
 1. Update version in `wp-fix-plugin-does-not-exist-notices.php` (both header and constructor call).
 2. Update `Stable tag:` in `readme.txt`.
 3. Add changelog entry to `readme.txt`, `CHANGELOG.md`, and `README.md`.
+4. Update the version string in `AGENTS.md` (item 1 of the Version Management list above).
 
 ### Add or fix update source logic
 


### PR DESCRIPTION
## Summary

Resolves #24

Addresses Gemini review feedback from PR #23 on `AGENTS.md`.

## Changes

**File**: `AGENTS.md`

Three improvements to the Version Management section:

1. **Fully qualified class name**: Changed `new Plugin(__FILE__, '2.4.0')` to `new WPALLSTARS\FixPluginDoesNotExistNotices\Plugin(__FILE__, '2.4.0')` — matches the actual instantiation in the PHP file, preventing agent search failures.

2. **Accurate version location list**: Removed `includes/Plugin.php` from the "four places" list (it has no version constant to update — only passes version via constructor). Added `AGENTS.md` itself as the fourth place (it now contains the hardcoded version string since PR #23).

3. **Bump version checklist**: Added step 4 to explicitly instruct updating `AGENTS.md` when bumping versions, closing the maintenance risk the reviewer identified.

## Verification

```bash
grep 'WPALLSTARS' AGENTS.md
# Expected: ...new WPALLSTARS\FixPluginDoesNotExistNotices\Plugin(__FILE__, '2.4.0')...

grep 'four places' AGENTS.md
# Expected: Version appears in **four places**

grep 'AGENTS.md' AGENTS.md | grep -v '^#'
# Expected: item 4 in version list + item 4 in bump-version checklist
```


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 3m and 8,032 tokens on this as a headless worker.