### PR TITLE
Resolve health dashboard runbook feedback (#34)

### DIFF
--- a/.ai-workflows/health-dashboard-remediation.md
+++ b/.ai-workflows/health-dashboard-remediation.md
@@ -5,18 +5,44 @@ Use this runbook when the repository supervisor health dashboard becomes stale.
 ## Signals
 
 - The pinned supervisor issue has an old `last_refresh:` marker.
-- The stats scheduler exists and is loaded, but wrapper runs overlap or remain active beyond the expected timeout.
+- The stats scheduler exists and is loaded, but wrapper runs overlap or remain
+  active beyond the expected timeout.
 - Recent stats logs stop before the affected repository is updated.
 
 ## Remediation
 
-1. Confirm the launchd job and stats log are present.
+1. Confirm the scheduler and stats log are present:
+
+   ```bash
+   launchctl list | grep -i aidevops-stats-wrapper
+   ls -la ~/Library/LaunchAgents/com.aidevops.aidevops-stats-wrapper.plist
+   tail -40 ~/.aidevops/logs/stats.log
+   ```
+
 2. Check for an active `stats-wrapper.sh` process that has exceeded `STATS_TIMEOUT`.
-3. Terminate the stale wrapper process, remove the stale stats pidfile, and run one targeted health issue refresh for this repository.
-4. Verify the pinned dashboard issue now has a fresh `last_refresh:` marker and recent `updated_at` timestamp.
+   The default timeout is `600` seconds and is defined near the top of
+   `~/.aidevops/agents/scripts/stats-wrapper.sh`; an operator can confirm the
+   runtime value with a dry run:
 
-## Verification evidence for issue #32
+   ```bash
+   STATS_DRY_RUN=1 bash ~/.aidevops/agents/scripts/stats-wrapper.sh --dry-run
+   ```
 
-- Scheduler plist existed and launchd reported `com.aidevops.aidevops-stats-wrapper` loaded.
-- The stats log showed repeated overlapping runs and a stale wrapper process, with the repository dashboard skipped before the targeted refresh.
-- A targeted refresh updated dashboard issue #10 with `last_refresh: 2026-05-10T00:38:30Z`.
+3. Terminate the stale wrapper process and remove the stale stats pidfile at
+   `~/.aidevops/logs/stats.pid`.
+
+4. Run one targeted health issue refresh for this repository:
+
+   ```bash
+   REPO_SLUG="wpallstars/wp-fix-plugin-does-not-exist-notices" \
+   REPO_PATH="$HOME/Git/wordpress/wp-fix-plugin-does-not-exist-notices" \
+   bash -lc '
+   source "$HOME/.aidevops/agents/scripts/shared-constants.sh"
+   source "$HOME/.aidevops/agents/scripts/worker-lifecycle-common.sh"
+   source "$HOME/.aidevops/agents/scripts/stats-functions.sh"
+   _update_health_issue_for_repo "$REPO_SLUG" "$REPO_PATH" "" "" ""
+   '
+   ```
+
+5. Verify the pinned dashboard issue now has a fresh `last_refresh:` marker and
+   recent `updated_at` timestamp.


### PR DESCRIPTION
## Summary
- Clarifies the health dashboard remediation runbook with the stats pidfile path, STATS_TIMEOUT source, and exact targeted health issue refresh invocation.
- Removes issue-specific verification evidence so the runbook remains evergreen.

## Testing
- markdownlint .ai-workflows/health-dashboard-remediation.md

Resolves #34

MERGE_SUMMARY: Clarified `.ai-workflows/health-dashboard-remediation.md` with operator-ready remediation details and removed stale issue-specific evidence.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 2m and 53,745 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated health dashboard remediation runbook with enhanced diagnostic signals for identifying issues.
  * Added detailed step-by-step remediation procedures with specific verification steps for resolving health dashboard problems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wpallstars/wp-fix-plugin-does-not-exist-notices/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->