### PR TITLE
Resolve health dashboard placeholder feedback (#36)

### DIFF
--- a/.ai-workflows/health-dashboard-remediation.md
+++ b/.ai-workflows/health-dashboard-remediation.md
@@ -34,8 +34,8 @@ Use this runbook when the repository supervisor health dashboard becomes stale.
 4. Run one targeted health issue refresh for this repository:
 
    ```bash
-   REPO_SLUG="wpallstars/wp-fix-plugin-does-not-exist-notices" \
-   REPO_PATH="$HOME/Git/wordpress/wp-fix-plugin-does-not-exist-notices" \
+   REPO_SLUG="<owner/repo>" \
+   REPO_PATH="<your/local/path>" \
    bash -lc '
    source "$HOME/.aidevops/agents/scripts/shared-constants.sh"
    source "$HOME/.aidevops/agents/scripts/worker-lifecycle-common.sh"


### PR DESCRIPTION
## Summary
- Replaced repository-specific `REPO_SLUG` and `REPO_PATH` examples in `.ai-workflows/health-dashboard-remediation.md` with reusable placeholders.

## Testing
- `git diff --check`
- Verified the issue-targeted hardcoded repository/path values are absent from `.ai-workflows/health-dashboard-remediation.md`.

<!-- MERGE_SUMMARY
Resolved review feedback from #36 by making the health dashboard remediation runbook evergreen: `.ai-workflows/health-dashboard-remediation.md` now uses `<owner/repo>` and `<your/local/path>` placeholders instead of repository-specific values. Verification: `git diff --check` and targeted content check for the removed hardcoded values.
-->

Resolves #36

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 68,607 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Health dashboard remediation runbook updated to use generic placeholders for repository identifiers, requiring operators to provide their own values when performing health issue refreshes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wpallstars/wp-fix-plugin-does-not-exist-notices/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->