### PR TITLE
docs: record dashboard recovery runbook

### DIFF
--- a/.ai-workflows/ops-dashboard.md
+++ b/.ai-workflows/ops-dashboard.md
@@ -1,0 +1,27 @@
+# Supervisor dashboard recovery
+
+The repository's aidevops supervisor dashboard is maintained outside the
+WordPress plugin runtime by the local stats scheduler. If a dashboard freshness
+alert reports that the pinned dashboard issue is stale while `stats.log` still
+shows hourly `Health issues: updated ... repo(s)` messages, verify the local
+health-issue cache before changing plugin code.
+
+## Triage
+
+1. Confirm the launchd job exists and is running.
+2. Inspect `~/.aidevops/logs/stats.log` for the affected repository.
+3. Check the pinned dashboard issue body for the `last_refresh:` marker.
+4. Confirm the cache file naming expected by the current aidevops version.
+
+## Cache migration failure mode
+
+Older aidevops releases wrote role-qualified cache files such as
+`health-issue-<user>-supervisor-<owner>-<repo>`. Current dashboard refresh code
+expects `health-issue-<canonical-user>-<owner>-<repo>`. If only the older cache
+file exists and the repository has no active PRs, assigned issues, or workers,
+the activity guard can skip resolving the already-open dashboard issue, leaving
+the existing dashboard stale.
+
+Restore the expected cache entry to the pinned dashboard issue number, then run
+the dashboard update path again. Verify that the pinned issue's `updated_at` and
+`last_refresh:` marker are current before closing the freshness alert.

--- a/.ai-workflows/readme.md
+++ b/.ai-workflows/readme.md
@@ -13,6 +13,7 @@ This directory contains workflow documentation for AI assistants working with th
 - **incremental-development.md**: Time-efficient approach for incremental development and testing
 - **local-env-vars.md**: Local development environment paths and URLs
 - **multi-repo-workspace.md**: Guidelines for working in workspaces with multiple repositories
+- **ops-dashboard.md**: Triage notes for aidevops supervisor dashboard freshness alerts
 - **release-process.md**: Steps for preparing and publishing new releases
 - **wiki-documentation.md**: Guidelines for maintaining wiki documentation
 


### PR DESCRIPTION
## Summary
- Restored the expected local aidevops health dashboard cache entry for this repository and refreshed pinned dashboard issue #10.
- Added an AI workflow runbook documenting the cache-migration failure mode that left the dashboard stale.
- Indexed the new runbook from `.ai-workflows/readme.md`.

## Root cause
The local stats scheduler was installed and running, but only the legacy role-qualified cache file existed for this repository (`health-issue-<user>-supervisor-<owner>-<repo>`). Current dashboard refresh code expects the roleless canonical cache filename. With no active PRs/issues/workers, the activity guard skipped resolving the already-open dashboard, leaving issue #10 stale.

## Verification
- `gh api repos/wpallstars/wp-fix-plugin-does-not-exist-notices/issues/10 --jq '{updated_at, last_refresh: (.body | capture("last_refresh: (?<ts>[^\\n]+)").ts)}'` → `updated_at=2026-05-19T07:26:49Z`, `last_refresh=2026-05-19T07:26:02Z`.
- `git diff --check -- .ai-workflows/readme.md .ai-workflows/ops-dashboard.md`
- `php -l wp-fix-plugin-does-not-exist-notices.php && php -l includes/Core.php && php -l includes/Plugin.php && php -l includes/Updater.php && php -l admin/lib/admin.php && php -l admin/lib/modal.php`
- `bash build.sh` was attempted but requires an explicit release version argument and is not suitable for this doc-only change.

Resolves #38

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 10m and 155,707 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operations dashboard troubleshooting documentation with triage procedures and recovery steps for resolving stale dashboard alerts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wpallstars/wp-fix-plugin-does-not-exist-notices/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->