### PR TITLE
docs: generalize scheduler wording

### DIFF
--- a/.ai-workflows/ops-dashboard.md
+++ b/.ai-workflows/ops-dashboard.md
@@ -8,7 +8,7 @@ health-issue cache before changing plugin code.
 
 ## Triage
 
-1. Confirm the launchd job exists and is running.
+1. Confirm the background scheduler job exists and is running.
 2. Inspect `~/.aidevops/logs/stats.log` for the affected repository.
 3. Check the pinned dashboard issue body for the `last_refresh:` marker.
 4. Confirm the cache file naming expected by the current aidevops version.


### PR DESCRIPTION
## Summary
- Generalized the ops dashboard triage step from a macOS-specific `launchd` reference to platform-neutral background scheduler wording.

## Verification
- `git diff --check HEAD~1..HEAD -- .ai-workflows/ops-dashboard.md`

Resolves #40

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 2m and 48,132 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational dashboard workflow documentation with revised scheduler job references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wpallstars/wp-fix-plugin-does-not-exist-notices/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->