### PR TITLE
docs: align scheduler wording

### DIFF
--- a/.ai-workflows/ops-dashboard.md
+++ b/.ai-workflows/ops-dashboard.md
@@ -8,7 +8,7 @@ health-issue cache before changing plugin code.
 
 ## Triage
 
-1. Confirm the background scheduler job exists and is running.
+1. Confirm the local stats scheduler job exists and is running.
 2. Inspect `~/.aidevops/logs/stats.log` for the affected repository.
 3. Check the pinned dashboard issue body for the `last_refresh:` marker.
 4. Confirm the cache file naming expected by the current aidevops version.


### PR DESCRIPTION
## Summary
- Align `.ai-workflows/ops-dashboard.md` triage wording with the local stats scheduler terminology used in the document introduction.

## Testing
- `git diff --check -- .ai-workflows/ops-dashboard.md`

Resolves #42

<!-- MERGE_SUMMARY
summary: Aligned the ops dashboard triage wording with the local stats scheduler terminology used in the document introduction.
testing: git diff --check -- .ai-workflows/ops-dashboard.md
-->

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.14 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 2m and 34,773 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
  * Updated recovery and triage guidance documentation to precisely reference the scheduler job confirmation procedure, aligning recovery instructions with current operational practices and established dashboard maintenance processes.
  * Improved overall documentation accuracy and clarity for system recovery procedures to ensure operational consistency, reduce confusion during troubleshooting scenarios, and support effective maintenance workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wpallstars/wp-fix-plugin-does-not-exist-notices/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->